### PR TITLE
Update directorySlider.js

### DIFF
--- a/directorySlider.js
+++ b/directorySlider.js
@@ -55,7 +55,8 @@
          $(val).css({
            position: 'absolute',
            top: 0,
-           left: 0
+           left: 0,
+           width: config.width // ADDED THIS SO WE DON'T NEED TO HAVE ALL IMAGES WITH SAME HEIGHT & WIDTH
          }).appendTo(slideWrap);
        });
 


### PR DESCRIPTION
Add the "width" property to the image (dinamycally) using the value set in the config options in case the images inside the directory doesn't have same width and height. It happened to me, I tested and it worked.